### PR TITLE
chore: remove debugger

### DIFF
--- a/src/components/extensions/languagetool.ts
+++ b/src/components/extensions/languagetool.ts
@@ -516,7 +516,6 @@ export const LanguageTool = Extension.create<LanguageToolOptions, LanguageToolSt
           handlePaste(view) {
             const { docChanged } = view.state.tr
 
-            debugger
             if (docChanged) debouncedProofreadAndDecorate(view.state.tr.doc)
 
             return false


### PR DESCRIPTION
[README says this file should be copied](https://github.com/sereneinserenade/tiptap-languagetool?tab=readme-ov-file#how-to-use) into my project. Would be nice if this comes without debugger statement. Or has this been added on purpose?